### PR TITLE
Add unplugin-vue-components

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@
 - [rspack-plugin-virtual-module](https://github.com/rspack-contrib/rspack-plugins/tree/main/packages/plugin-virtual-module): A plugin for rspack that allows you to create virtual modules.
 - [html-rspack-plugin](https://github.com/rspack-contrib/html-rspack-plugin): Generate files to serve your Rspack bundles.
 
+You can also use most of the [unplugin](https://github.com/unplugin) in Rspack or Rsbuild, such as:
+
+- [unplugin-vue-components](https://github.com/unplugin/unplugin-vue-components): On-demand components auto importing for Vue.
+
 ### Rsbuild Plugins
 
 - [@rsbuild/plugin-react](https://rsbuild.dev/plugins/list/plugin-react): Provides support for React.


### PR DESCRIPTION
[unplugin-vue-components](https://github.com/unplugin/unplugin-vue-components): On-demand components auto importing for Vue.