### PR TITLE
docs: add TanStacked boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Upper-level frameworks or libraries that are powered by Rspack or connected to R
 ### Rsbuild Starter
 
 - [react-tailwind-rsbuild-boilerplate](https://github.com/alonronin/react-tailwind-rsbuild-boilerplate): React + React Router + Tailwind CSS with Rsbuild boilerplate.
+- [TanStacked](https://github.com/mohmmedraad/TanStacked): React + Tanstack Router + Shadcn + Tailwind CSS v4 And Biome with Rsbuild boilerplate.
 - [rsbuild_vue3_h5_template](https://github.com/DMaiGit/rsbuild_vue3_h5_template): A project template for Vue 3. It includes popular libraries such as Axios, Pinia, Vant, and Vue Router.
 - [rsbuild-chrome-extension-boilerplate-react](https://github.com/filc-dev/rsbuild-chrome-extension-boilerplate-react): Chrome extension boilerplate for Rsbuild.
 - [rsbuild-plugin-template](https://github.com/rspack-contrib/rsbuild-plugin-template): Use this template to create your own Rsbuild plugin.


### PR DESCRIPTION
This PR adds **TanStacked**, a modern Rspack boilerplate featuring:
- ✅ React 19 
- ✅ TanStack Router  
- ✅ ShadCN Components  
- ✅ Tailwind CSS v4  
- ✅ Biome  
- ✅ Rsbuild  

TanStacked helps developers quickly set up a React project with tanstack router and  Rspack.  
Check out the repository: [TanStacked Repo](https://github.com/mohmmedraad/TanStacked).
