### PR TITLE
docs: add rspack-circular-dependency-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Upper-level frameworks or libraries that are powered by Rspack or connected to R
 - [typia-rspack-plugin](https://github.com/colinaaa/typia-rspack-plugin): A Rspack plugin for `typia` - TypeScript transformer for runtime type checking and validation.
 - [sonda](https://github.com/filipsobol/sonda): Visualizer and analyzer for JavaScript and CSS bundles.
 - [rspack-deno-plugin](https://github.com/LonelySnowman/rspack-deno-plugin): Make Rspack run correctly in the deno environment.
+- [rspack-circular-dependency-plugin](https://github.com/Sunny-117/rspack-circular-dependency-plugin): Detect circular dependencies in modules compiled with Rspack.
 
 Rspack and Rsbuild support most of the webpack plugins, such as:
 


### PR DESCRIPTION
circular-dependency-plugin cannot adapt to rspack, and has a lot of webpack4 and webpack5 judgment logic inside