### PR TITLE
Add some Lynx Rsbuild plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
     A curated list of awesome things related to <a href='https://github.com/web-infra-dev/rspack'>Rspack</a> and its ecology
 </p>
 
-<br><br>
-
 <h1>Awesome Rspack</h1>
 
 - [Resources](#resources)
@@ -194,6 +192,11 @@ Rspack and Rsbuild support most of the [unplugin](https://github.com/unplugin), 
 #### For Solid
 
 - [@rsbuild/plugin-solid](https://rsbuild.dev/plugins/list/plugin-solid): Provides support for Solid.
+
+#### For Lynx
+
+- [relog-rsbuild-plugin](https://github.com/nanofuxion/relog-rsbuild-plugin): Allows you to intercept `console.log()` calls from your LynxJS app running on a device or emulator and send them back to the Rsbuild dev server.
+- [ngrok-rsbuild-plugin](https://github.com/nanofuxion/ngrok-rsbuild-plugin): Expose your Rsbuild dev server over the internet via ngrok — built for use with the LynxJS app.
 
 #### Common
 


### PR DESCRIPTION

- [relog-rsbuild-plugin](https://github.com/nanofuxion/relog-rsbuild-plugin): Allows you to intercept `console.log()` calls from your LynxJS app running on a device or emulator and send them back to the Rsbuild dev server.
- [ngrok-rsbuild-plugin](https://github.com/nanofuxion/ngrok-rsbuild-plugin): Expose your Rsbuild dev server over the internet via ngrok — built for use with the LynxJS app.