### PR TITLE
Add ts-lib-starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Upper-level frameworks or libraries that are powered by Rspack or connected to R
 
 ### Rslib Starter
 
+- [ts-lib-starter](https://github.com/ulivz/ts-lib-starter): A hassle-free TS library template, powered by Rslib.
 - [rslib-npm-template](https://github.com/LLmoskk/rslib-npm-template): A starter template for developing React components with Rslib, featuring automated versioning and publishing using semantic-release.
 - [web-component-starter](https://github.com/holyfata/web-component-starter): A starter for developint Web components with Rslib, featuring using stencil and useful both in React and Vue.
 


### PR DESCRIPTION
- [ts-lib-starter](https://github.com/ulivz/ts-lib-starter): A hassle-free TS library template, powered by Rslib.