### PR TITLE
docs: add rspress-plugin-pdf-generator to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ Rspack and Rsbuild support most of the webpack loaders, such as:
 - [rspress-plugin-auto-sidebar](https://github.com/buyfakett/rspress-plugin-auto-sidebar): Automatically generate the sidebar from the navbar configuration.
 - [rspress-plugin-giscus](https://github.com/buyfakett/rspress-plugin-giscus): Integrate [giscus](https://github.com/giscus/giscus) into Rspress, a comment system powered by GitHub Discussions.
 - [rspress-plugin-blog-list](https://github.com/buyfakett/rspress-plugin-blog-list): Integrate blog list into Rspress.
+- [rspress-plugin-pdf-generator](https://github.com/MaxtuneLee/rspress-plugin-pdf-generator): Generates multi-language single-page or multi-page PDF documents from Rspress site during build process.
 
 ### Unplugin
 


### PR DESCRIPTION
## What
rspress-plugin-pdf-generator is an Rspress plugin designed to automatically render and compile documentation pages into PDF files during the site build process.

repo: https://github.com/MaxtuneLee/rspress-plugin-pdf-generator

## Files touched
Add rspress-plugin-pdf-generator to README.
